### PR TITLE
Add users page with mock backend support

### DIFF
--- a/novadocs/README.md
+++ b/novadocs/README.md
@@ -9,6 +9,7 @@ A modern, self-hosted collaborative wiki platform built with Next.js, FastAPI, a
 - 📊 Database views (Table, Kanban, Calendar)
 - 🔍 Full-text and semantic search
 - 🔒 Role-based permissions
+- 👥 User management interface
 - 📱 Mobile-responsive design
 - 🚀 Fast and scalable architecture
 
@@ -28,6 +29,7 @@ npm run dev
 ## Development
 
 - Frontend: http://localhost:3000
+- Users page: http://localhost:3000/users
 - Backend API: http://localhost:8000
 - GraphQL Playground: http://localhost:8000/graphql
 - PostgreSQL: localhost:5432

--- a/novadocs/apps/frontend/src/app/users/page.tsx
+++ b/novadocs/apps/frontend/src/app/users/page.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { useForm } from 'react-hook-form'
+
+interface User {
+  id: string | number
+  name: string
+  email: string
+  avatar_url?: string
+}
+
+export default function UsersPage() {
+  const [users, setUsers] = useState<User[]>([])
+  const [loading, setLoading] = useState(true)
+  const { register, handleSubmit, reset } = useForm<{ name: string; email: string }>()
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchUsers()
+  }, [])
+
+  const fetchUsers = async () => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/users`)
+      if (res.ok) {
+        const data = await res.json()
+        setUsers(data.users)
+      } else {
+        setError(`Failed to load users: ${res.status}`)
+      }
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const onSubmit = async (values: { name: string; email: string }) => {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values)
+      })
+
+      if (res.ok) {
+        const data = await res.json()
+        setUsers((prev) => [...prev, data.user])
+        reset()
+      } else {
+        setError(`Failed to create user: ${res.status}`)
+      }
+    } catch (err: any) {
+      setError(err.message)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading users...</p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="bg-white border-b">
+        <div className="container mx-auto px-4 py-4 flex items-center space-x-4">
+          <Link href="/" className="text-blue-600 hover:text-blue-800">
+            ← Back to Home
+          </Link>
+          <h1 className="text-xl font-semibold text-gray-900">Users</h1>
+        </div>
+      </div>
+
+      <div className="container mx-auto px-4 py-8">
+        <div className="max-w-xl mx-auto mb-8">
+          <form onSubmit={handleSubmit(onSubmit)} className="bg-white border p-6 rounded-lg space-y-4">
+            <h2 className="text-lg font-semibold text-gray-900 mb-2">Add New User</h2>
+            {error && <p className="text-red-600 text-sm">{error}</p>}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Name</label>
+              <input
+                {...register('name', { required: true })}
+                className="w-full border rounded-md px-3 py-2"
+                placeholder="Full name"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+              <input
+                {...register('email', { required: true })}
+                className="w-full border rounded-md px-3 py-2"
+                placeholder="user@example.com"
+              />
+            </div>
+            <button
+              type="submit"
+              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md"
+            >
+              Create User
+            </button>
+          </form>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {users.map((user) => (
+            <div key={user.id} className="bg-white rounded-lg shadow-sm border p-6 flex items-center space-x-4">
+              {user.avatar_url && (
+                <Image
+                  src={user.avatar_url}
+                  alt={user.name}
+                  width={48}
+                  height={48}
+                  className="rounded-full"
+                />
+              )}
+              <div>
+                <p className="text-lg font-semibold text-gray-900">{user.name}</p>
+                <p className="text-sm text-gray-600">{user.email}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/novadocs/mock-backend.js
+++ b/novadocs/mock-backend.js
@@ -10,7 +10,13 @@ app.use(express.json());
 
 // Mock data storage
 let pages = [];
+let users = [
+  { id: 1, name: 'Alice Doe', email: 'alice@example.com', avatar_url: 'https://i.pravatar.cc/100?u=alice' },
+  { id: 2, name: 'Bob Smith', email: 'bob@example.com', avatar_url: 'https://i.pravatar.cc/100?u=bob' },
+  { id: 3, name: 'Charlie Brown', email: 'charlie@example.com', avatar_url: 'https://i.pravatar.cc/100?u=charlie' }
+];
 let currentId = 1;
+let userId = users.length + 1;
 
 // Health check endpoints
 const healthResponse = {
@@ -93,6 +99,24 @@ app.get('/api/v1/pages/:id', (req, res) => {
   }
 });
 
+// Users API
+app.get('/api/v1/users', (req, res) => {
+  console.log('👥 Getting all users');
+  res.json({ users });
+});
+
+app.post('/api/v1/users', (req, res) => {
+  console.log('👥 Creating new user:', req.body);
+  const user = {
+    id: userId++,
+    name: req.body.name,
+    email: req.body.email,
+    avatar_url: `https://i.pravatar.cc/100?u=${encodeURIComponent(req.body.email)}`
+  };
+  users.push(user);
+  res.json({ user, message: 'User created successfully' });
+});
+
 // File upload endpoint
 app.post('/api/v1/upload', (req, res) => {
   console.log('📁 File upload requested');
@@ -108,7 +132,7 @@ app.post('/api/v1/upload', (req, res) => {
 app.get('/api/v1/stats', (req, res) => {
   res.json({
     pages: pages.length,
-    users: 3,
+    users: users.length,
     workspaces: 1,
     storage_used: '12.5 MB'
   });
@@ -120,4 +144,5 @@ app.listen(8000, () => {
   console.log('📊 API Health check: http://localhost:8000/api/health');
   console.log('🎯 GraphQL: http://localhost:8000/graphql');
   console.log('📄 Pages API: http://localhost:8000/api/v1/pages');
+  console.log('👥 Users API: http://localhost:8000/api/v1/users');
 });


### PR DESCRIPTION
## Summary
- add users management page in the frontend
- add mock users API endpoints
- expose users route in mock backend logs
- document the new page in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e82cf12108328961bd76598c77066