### PR TITLE
Allow pravatar domain for images

### DIFF
--- a/novadocs/apps/frontend/next.config.js
+++ b/novadocs/apps/frontend/next.config.js
@@ -3,7 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   images: {
-    domains: ['localhost', '127.0.0.1'],
+    domains: ['localhost', '127.0.0.1', 'i.pravatar.cc'],
     formats: ['image/avif', 'image/webp']
   },
   webpack: (config, { isServer }) => {


### PR DESCRIPTION
## Summary
- add `i.pravatar.cc` to allowed Next.js image domains

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7717789883289e43dd68bccabc3f