### PR TITLE
Add React Query provider to RootLayout

### DIFF
--- a/novadocs/apps/frontend/src/app/layout.tsx
+++ b/novadocs/apps/frontend/src/app/layout.tsx
@@ -2,6 +2,8 @@ import './globals.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import AppLayout from '@/components/layout/AppLayout'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useState } from 'react'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -15,12 +17,23 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  const [queryClient] = useState(() => new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+        retry: 1,
+      },
+    },
+  }))
+
   return (
     <html lang="en">
       <body className={inter.className}>
-        <AppLayout>
-          {children}
-        </AppLayout>
+        <QueryClientProvider client={queryClient}>
+          <AppLayout>
+            {children}
+          </AppLayout>
+        </QueryClientProvider>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- initialize `QueryClient` in the app router layout
- wrap content with `QueryClientProvider`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7e7490c88328a27bc77235f01f87